### PR TITLE
Implement configurable settings loader

### DIFF
--- a/cli/cli_main.py
+++ b/cli/cli_main.py
@@ -1,47 +1,39 @@
 import argparse
+import json
+import logging
 import os
+import signal
 import sys
 import time
 
 from utils import programs
 
-from utils.logger import get_logger
-from utils.transfer import copy_file_resumable
+from utils.logger import get_logger, configure_logger
 from utils.permissions import copy_with_permissions
+from utils.config import load_config, apply_cli_overrides
+from utils.transfer_control import TransferControl
+from utils.restore import generate_restore_script
 
-def _dir_size(path: str) -> int:
-    """Return directory size in bytes."""
-    total = 0
-    for root, _, files in os.walk(path):
-        for f in files:
-            fp = os.path.join(root, f)
-            try:
-                total += os.path.getsize(fp)
-            except OSError:
-                pass
-    return total
+PRESET_DIR = os.path.expanduser("~/.migration-assistant/presets")
 
-def select_directory() -> str | None:
-    """Prompt the user to select a directory via text input."""
-    while True:
-        path = input("Enter directory path (or 'q' to cancel): ").strip().strip('"')
-        if path.lower() == 'q' or not path:
-            print("No directory selected.")
-            return None
-        if not os.path.isdir(path):
-            print("Directory does not exist. Try again.")
-            continue
-        size = _dir_size(path)
-        print(f"Selected: {path}")
-        print(f"Estimated space required: {size} bytes")
-        confirm = input("Use this directory? (y/n): ").strip().lower()
-        if confirm == 'y':
-            return path
-        elif confirm == 'n':
-            continue
-        else:
-            print("Canceled.")
-            return None
+logger = get_logger(__name__)
+
+def _path_size(path: str) -> int:
+    """Return file or directory size in bytes."""
+    if os.path.isdir(path):
+        total = 0
+        for root, _, files in os.walk(path):
+            for f in files:
+                fp = os.path.join(root, f)
+                try:
+                    total += os.path.getsize(fp)
+                except OSError:
+                    pass
+        return total
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
 
 def select_directory() -> str | None:
     """Prompt the user to select a directory via text input."""
@@ -53,7 +45,7 @@ def select_directory() -> str | None:
         if not os.path.isdir(path):
             print("Directory does not exist. Try again.")
             continue
-        size = _dir_size(path)
+        size = _path_size(path)
         print(f"Selected: {path}")
         print(f"Estimated space required: {size} bytes")
         confirm = input("Use this directory? (y/n): ").strip().lower()
@@ -64,20 +56,49 @@ def select_directory() -> str | None:
         else:
             print("Canceled.")
             return None
-    logger = get_logger(__name__)
 
 
-def _print_progress(copied: int, total: int, start: float) -> None:
-    """Print a simple progress bar to stdout."""
-    percent = copied / total * 100 if total else 100
-    bar_len = 30
-    filled = int(bar_len * percent / 100)
-    bar = '#' * filled + '-' * (bar_len - filled)
-    speed = copied / max(time.time() - start, 1e-3)
-    eta = (total - copied) / speed if speed > 0 else 0
-    msg = f"\r[{bar}] {percent:5.1f}% {copied}/{total} bytes ETA {eta:0.1f}s"
-    sys.stdout.write(msg)
-    sys.stdout.flush()
+def select_items_cli() -> list[str] | None:
+    """Interactively select multiple files or folders."""
+    print("Enter file or directory paths. Leave blank when done.")
+    selections: list[str] = []
+    while True:
+        path = input("Path: ").strip().strip('"')
+        if not path:
+            break
+        if not os.path.exists(path):
+            print("Path does not exist. Try again.")
+            continue
+        selections.append(path)
+        size = sum(_path_size(p) for p in selections)
+        print(f"Current total size: {size} bytes")
+    if not selections:
+        print("No items selected.")
+        return None
+    confirm = input("Use these selections? (y/n): ").strip().lower()
+    if confirm != "y":
+        return None
+    return selections
+
+
+def save_preset(name: str, paths: list[str]) -> str:
+    """Save the selected paths as a preset and return the file path."""
+    os.makedirs(PRESET_DIR, exist_ok=True)
+    if not name.endswith(".json"):
+        name += ".json"
+    preset_path = os.path.join(PRESET_DIR, name)
+    with open(preset_path, "w", encoding="utf-8") as f:
+        json.dump(paths, f, indent=2)
+    return preset_path
+
+
+def load_preset_file(path: str) -> list[str]:
+    """Load file paths from a preset."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError("Preset must contain a list of paths")
+    return [str(p) for p in data]
 
 
 def _print_progress(copied: int, total: int, start: float) -> None:
@@ -96,19 +117,114 @@ def _print_retry(remaining: int) -> None:
     sys.stdout.write(f"\rRetrying in {remaining}s...     ")
     sys.stdout.flush()
 
+
+def copy_items(
+    sources: list[str],
+    dst_root: str,
+    config,
+    control: TransferControl,
+) -> bool:
+    """Copy multiple files or directories to a destination root."""
+    total_size = sum(_path_size(p) for p in sources)
+    copied_total = 0
+    start = time.time()
+
+    def make_update(offset: int):
+        return lambda c, t: _print_progress(offset + c, total_size, start)
+
+    for src in sources:
+        if control.cancel.is_set():
+            return False
+        if os.path.isdir(src):
+            base = os.path.basename(src.rstrip(os.sep))
+            for root, _, files in os.walk(src):
+                for f in files:
+                    if control.cancel.is_set():
+                        return False
+                    src_file = os.path.join(root, f)
+                    rel = os.path.relpath(src_file, src)
+                    dst = os.path.join(dst_root, base, rel)
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    file_size = os.path.getsize(src_file)
+                    cb = make_update(copied_total)
+                    if not copy_with_permissions(
+                        src_file,
+                        dst,
+                        cli=True,
+                        progress_cb=cb,
+                        retry_cb=_print_retry,
+                        timeout=config.timeout,
+                        chunk_size=config.chunk_size,
+                        control=control,
+                    ):
+                        return False
+                    copied_total += file_size
+        else:
+            dst = os.path.join(dst_root, os.path.basename(src))
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            file_size = os.path.getsize(src)
+            cb = make_update(copied_total)
+            if not copy_with_permissions(
+                src,
+                dst,
+                cli=True,
+                progress_cb=cb,
+                retry_cb=_print_retry,
+                timeout=config.timeout,
+                chunk_size=config.chunk_size,
+                control=control,
+            ):
+                return False
+            copied_total += file_size
+    print()  # newline after progress bar
+    return True
+
 def run_cli(args=None) -> None:
     """Entry point for the CLI mode."""
     parser = argparse.ArgumentParser(description="WinMigrate CLI")
-    parser.add_argument('--option', help='Placeholder option')
+    parser.add_argument('--config', help='Path to configuration file')
+    parser.add_argument('--timeout', type=int, help='Timeout duration in seconds')
+    parser.add_argument('--verbosity', help='Logging verbosity level')
+    parser.add_argument('--chunk-size', type=int, help='Transfer block size in bytes')
+    parser.add_argument('--log-path', help='Path to log file')
+    parser.add_argument('--preset', help='Path to file selection preset')
     parser.add_argument(
-        '--transfer', nargs=2, metavar=('SRC', 'DST'),
-        help='Transfer file from SRC to DST'
+        '--save-preset', nargs='?', const=True, metavar='NAME',
+        help='Save selection as preset with NAME (prompt if NAME omitted)'
+    )
+    parser.add_argument(
+        '--transfer', nargs='+', metavar=('SRC', 'DST'),
+        help='Transfer file(s). Provide only DST when used with --preset'
     )
     parser.add_argument(
         '--installed-report', nargs='?', metavar='DIR', const='',
         help='Generate installed programs report in DIR (prompt if omitted)'
     )
+    parser.add_argument('--restore-script', help='Write PowerShell restore script to PATH')
+    parser.add_argument('--program-json', help='Installed programs JSON for restore script')
     parsed_args = parser.parse_args(args)
+
+    config = load_config(parsed_args.config)
+    config = apply_cli_overrides(config, parsed_args)
+    level = getattr(logging, config.verbosity.upper(), logging.INFO)
+    configure_logger(level=level, log_path=config.log_path)
+
+    control = TransferControl()
+
+    def _handle_sigint(signum, frame):
+        if control.pause.is_set():
+            control.cancel.set()
+            print("\nCanceling transfer...")
+            return
+        control.pause.set()
+        print("\nTransfer paused. Resume (r) or cancel (c)? ", end="", flush=True)
+        choice = sys.stdin.readline().strip().lower()
+        if choice == "r":
+            control.pause.clear()
+        else:
+            control.cancel.set()
+
+    old_handler = signal.signal(signal.SIGINT, _handle_sigint)
 
     logger.info("Running CLI with args: %s", parsed_args)
     print("=== WinMigrate CLI ===")
@@ -121,25 +237,92 @@ def run_cli(args=None) -> None:
             path = programs.generate_report(output_dir)
             print(f'Report generated at {path}')
     elif parsed_args.transfer:
-        src, dst = parsed_args.transfer
-        start = time.time()
-        progress = lambda c, t: _print_progress(c, t, start)
-        success = copy_with_permissions(
-            src,
-            dst,
-            cli=True,
-            progress_cb=progress,
-            retry_cb=_print_retry,
-        )
-        print()  # newline after progress bar
-        if success:
-            print("Transfer completed. See winmigrate.log for details.")
+        pairs = []
+        if parsed_args.preset:
+            if len(parsed_args.transfer) != 1:
+                parser.error('--transfer requires DEST only when using --preset')
+            dst_root = parsed_args.transfer[0]
+            sources = load_preset_file(parsed_args.preset)
+            success = copy_items(sources, dst_root, config, control)
+            pairs = [
+                (s, os.path.join(dst_root, os.path.basename(s.rstrip(os.sep))))
+                for s in sources
+            ]
         else:
-            print("Transfer failed or canceled. See winmigrate.log for details.")
+            if len(parsed_args.transfer) != 2:
+                parser.error('--transfer requires SRC and DST')
+            src, dst = parsed_args.transfer
+            start = time.time()
+            progress = lambda c, t: _print_progress(c, t, start)
+            success = copy_with_permissions(
+                src,
+                dst,
+                cli=True,
+                progress_cb=progress,
+                retry_cb=_print_retry,
+                timeout=config.timeout,
+                chunk_size=config.chunk_size,
+                control=control,
+            )
+            pairs = [(src, dst)]
+        if success:
+            print(f"Transfer completed. See {config.log_path} for details.")
+            if parsed_args.restore_script:
+                generate_restore_script(
+                    pairs,
+                    parsed_args.restore_script,
+                    program_json=parsed_args.program_json,
+                )
+                print(
+                    f"Restore script written to {parsed_args.restore_script}. Review before running."
+                )
+        else:
+            print(
+                f"Transfer failed or canceled. See {config.log_path} for details."
+            )
+        signal.signal(signal.SIGINT, old_handler)
     else:
-        path = select_directory()
-        if path:
-            logger.info("User confirmed directory: %s", path)
+        if parsed_args.preset:
+            sources = load_preset_file(parsed_args.preset)
+        else:
+            sources = select_items_cli()
+            if sources and parsed_args.save_preset:
+                name = parsed_args.save_preset
+                if name is True:
+                    name = input('Preset name: ').strip()
+                if name:
+                    p = save_preset(name, sources)
+                    print(f'Saved preset to {p}')
+        if not sources:
+            return
+        dst_root = input('Enter destination directory: ').strip().strip('"')
+        if not dst_root:
+            print('No destination specified.')
+            return
+        success = copy_items(sources, dst_root, config, control)
+        pairs = [
+            (s, os.path.join(dst_root, os.path.basename(s.rstrip(os.sep))))
+            for s in sources
+        ]
+        if success:
+            print(f"Transfer completed. See {config.log_path} for details.")
+            if parsed_args.restore_script:
+                generate_restore_script(
+                    pairs,
+                    parsed_args.restore_script,
+                    program_json=parsed_args.program_json,
+                )
+                print(
+                    f"Restore script written to {parsed_args.restore_script}. Review before running."
+                )
+        else:
+            print(
+                f"Transfer failed or canceled. See {config.log_path} for details."
+            )
+        signal.signal(signal.SIGINT, old_handler)
+    
+    if not parsed_args.transfer and not parsed_args.installed_report:
+        logger.info("User confirmed directory: %s", ' '.join(sources) if parsed_args.preset or sources else '')
 
 if __name__ == '__main__':
     run_cli()

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "timeout": 300,
+  "verbosity": "INFO",
+  "chunk_size": 1048576,
+  "log_path": "winmigrate.log"
+}

--- a/config.json
+++ b/config.json
@@ -2,5 +2,7 @@
   "timeout": 300,
   "verbosity": "INFO",
   "chunk_size": 1048576,
-  "log_path": "winmigrate.log"
+  "log_path": "winmigrate.log",
+  "csv_log_path": "winmigrate.csv",
+  "accessible": false
 }

--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -162,7 +162,12 @@ def launch_gui() -> None:
     """Launch the GUI mode of the application."""
     config = load_config(None)
     level = getattr(logging, config.verbosity.upper(), logging.INFO)
-    configure_logger(level=level, log_path=config.log_path)
+    configure_logger(
+        level=level,
+        log_path=config.log_path,
+        csv_log_path=config.csv_log_path,
+        accessible=config.accessible,
+    )
     logger.info("Launching GUI")
     root = tk.Tk()
     root.title("WinMigrate - Transfer Method Selection")

--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -1,19 +1,147 @@
 import os
+import json
+import threading
+import time
 import tkinter as tk
 
 from tkinter import ttk, filedialog, messagebox
-from utils.logger import get_logger
-from utils.transfer import copy_file_resumable
-import time
-import logging
+from utils.logger import get_logger, configure_logger
 from utils import programs
 from utils.permissions import copy_with_permissions
+from utils.config import load_config
+from utils.transfer_control import TransferControl
+from utils.restore import generate_restore_script
+from typing import Callable
+import logging
 
 logger = get_logger(__name__)
 
 
+def _path_size(path: str) -> int:
+    """Return size of a file or directory in bytes."""
+    if os.path.isdir(path):
+        total = 0
+        for root, _, files in os.walk(path):
+            for f in files:
+                fp = os.path.join(root, f)
+                try:
+                    total += os.path.getsize(fp)
+                except OSError:
+                    pass
+        return total
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
+def select_items(parent: tk.Tk) -> list[str] | None:
+    """Open a dialog to select multiple files and folders."""
+    dialog = tk.Toplevel(parent)
+    dialog.title("Select Items")
+    paths: list[str] = []
+
+    listbox = tk.Listbox(dialog, width=60, selectmode=tk.EXTENDED)
+    listbox.pack(padx=10, pady=5, fill="both", expand=True)
+
+    size_var = tk.StringVar(value="Total size: 0 bytes")
+    tk.Label(dialog, textvariable=size_var).pack(pady=2)
+
+    def _update_size() -> None:
+        total = sum(_path_size(p) for p in paths)
+        size_var.set(f"Total size: {total} bytes")
+
+    def _add_files() -> None:
+        files = filedialog.askopenfilenames(parent=dialog)
+        for f in files:
+            if f and f not in paths:
+                paths.append(f)
+                listbox.insert(tk.END, f)
+        _update_size()
+
+    def _add_folder() -> None:
+        folder = filedialog.askdirectory(parent=dialog)
+        if folder and folder not in paths:
+            paths.append(folder)
+            listbox.insert(tk.END, folder)
+            _update_size()
+
+    def _remove_selected() -> None:
+        sel = list(listbox.curselection())
+        for index in reversed(sel):
+            item = listbox.get(index)
+            paths.remove(item)
+            listbox.delete(index)
+        _update_size()
+
+    def _save_preset() -> None:
+        fp = filedialog.asksaveasfilename(
+            parent=dialog,
+            defaultextension=".json",
+            filetypes=[("Preset", "*.json"), ("Backup Job", "*.bakjob")],
+        )
+        if fp:
+            try:
+                with open(fp, "w", encoding="utf-8") as f:
+                    json.dump(paths, f, indent=2)
+            except Exception as exc:
+                messagebox.showerror("Error", str(exc), parent=dialog)
+
+    def _load_preset() -> None:
+        fp = filedialog.askopenfilename(
+            parent=dialog,
+            filetypes=[("Preset", "*.json"), ("Backup Job", "*.bakjob")],
+        )
+        if not fp:
+            return
+        try:
+            with open(fp, "r", encoding="utf-8") as f:
+                items = json.load(f)
+            paths.clear()
+            listbox.delete(0, tk.END)
+            for item in items:
+                paths.append(item)
+                listbox.insert(tk.END, item)
+            _update_size()
+        except Exception as exc:
+            messagebox.showerror("Error", str(exc), parent=dialog)
+
+    btn_frame = tk.Frame(dialog)
+    btn_frame.pack(pady=5)
+    tk.Button(btn_frame, text="Add Files", command=_add_files).pack(side="left", padx=2)
+    tk.Button(btn_frame, text="Add Folder", command=_add_folder).pack(side="left", padx=2)
+    tk.Button(btn_frame, text="Remove", command=_remove_selected).pack(side="left", padx=2)
+    tk.Button(btn_frame, text="Load Preset", command=_load_preset).pack(side="left", padx=2)
+    tk.Button(btn_frame, text="Save Preset", command=_save_preset).pack(side="left", padx=2)
+
+    result: list[str] | None = []
+
+    def _ok() -> None:
+        nonlocal result
+        result = paths.copy()
+        dialog.destroy()
+
+    def _cancel() -> None:
+        nonlocal result
+        result = None
+        dialog.destroy()
+
+    action_frame = tk.Frame(dialog)
+    action_frame.pack(pady=5)
+    tk.Button(action_frame, text="OK", width=10, command=_ok).pack(side="left", padx=5)
+    tk.Button(action_frame, text="Cancel", width=10, command=_cancel).pack(side="left", padx=5)
+
+    dialog.transient(parent)
+    dialog.grab_set()
+    parent.wait_window(dialog)
+    return result
+
+
 def launch_gui() -> None:
     """Launch the GUI mode of the application."""
+    config = load_config(None)
+    level = getattr(logging, config.verbosity.upper(), logging.INFO)
+    configure_logger(level=level, log_path=config.log_path)
     logger.info("Launching GUI")
     root = tk.Tk()
     root.title("WinMigrate - Transfer Method Selection")
@@ -29,6 +157,40 @@ def launch_gui() -> None:
 
     progress = ttk.Progressbar(frame, length=300)
     progress.pack(pady=5, fill="x")
+
+    control = TransferControl()
+
+    btn_frame = tk.Frame(frame)
+    btn_frame.pack(pady=5)
+    pause_btn = tk.Button(btn_frame, text="Pause", state="disabled")
+    resume_btn = tk.Button(btn_frame, text="Resume", state="disabled")
+    cancel_btn = tk.Button(btn_frame, text="Cancel", state="disabled")
+    pause_btn.pack(side="left", padx=5)
+    resume_btn.pack(side="left", padx=5)
+    cancel_btn.pack(side="left", padx=5)
+
+    def pause_transfer() -> None:
+        control.pause.set()
+        pause_btn.config(state="disabled")
+        resume_btn.config(state="normal")
+        status_var.set("Paused")
+
+    def resume_transfer() -> None:
+        control.pause.clear()
+        pause_btn.config(state="normal")
+        resume_btn.config(state="disabled")
+        status_var.set("Resuming...")
+
+    def cancel_transfer() -> None:
+        control.cancel.set()
+        pause_btn.config(state="disabled")
+        resume_btn.config(state="disabled")
+        cancel_btn.config(state="disabled")
+        status_var.set("Canceling...")
+
+    pause_btn.config(command=pause_transfer)
+    resume_btn.config(command=resume_transfer)
+    cancel_btn.config(command=cancel_transfer)
 
     status_var = tk.StringVar(value="")
     status_label = tk.Label(frame, textvariable=status_var)
@@ -56,43 +218,160 @@ def launch_gui() -> None:
         path = programs.generate_report(out_dir)
         messagebox.showinfo("Report", f"Report generated at {path}", parent=root)
 
+    def restore_wizard() -> None:
+        preset = filedialog.askopenfilename(
+            title="Select Preset", parent=root, filetypes=[("Preset", "*.json")]
+        )
+        if not preset:
+            return
+        try:
+            with open(preset, "r", encoding="utf-8") as f:
+                sources = json.load(f)
+            if not isinstance(sources, list):
+                raise ValueError("Invalid preset file")
+        except Exception as exc:
+            messagebox.showerror("Error", str(exc), parent=root)
+            return
+        backup_root = filedialog.askdirectory(title="Select Backup Root", parent=root)
+        if not backup_root:
+            return
+        program_json = filedialog.askopenfilename(
+            title="Select Program JSON (optional)",
+            parent=root,
+            filetypes=[("JSON", "*.json"), ("All", "*")],
+        )
+        script_path = filedialog.asksaveasfilename(
+            title="Save Restore Script",
+            defaultextension=".ps1",
+            filetypes=[("PowerShell", "*.ps1")],
+            parent=root,
+        )
+        if not script_path:
+            return
+        pairs = [
+            (s, os.path.join(backup_root, os.path.basename(s.rstrip(os.sep))))
+            for s in sources
+        ]
+        generate_restore_script(pairs, script_path, program_json or None)
+        messagebox.showinfo(
+            "Restore Script",
+            f"Script saved to {script_path}. Review before running.",
+            parent=root,
+        )
+
     def choose_and_transfer() -> None:
-        src = filedialog.askopenfilename(title="Select Source File", parent=root)
-        if not src:
+        sources = select_items(root)
+        if not sources:
             return
-        dst = filedialog.asksaveasfilename(title="Select Destination", parent=root)
-        if not dst:
+        dst_root = filedialog.askdirectory(title="Select Destination Directory", parent=root)
+        if not dst_root:
             return
 
+        control.pause.clear()
+        control.cancel.clear()
         start = time.time()
+        pause_btn.config(state="normal")
+        cancel_btn.config(state="normal")
+        resume_btn.config(state="disabled")
+        status_var.set("Transferring...")
 
-        def update(copied: int, total: int) -> None:
-            percent = copied / total * 100 if total else 100
-            progress['value'] = percent
-            logger.debug("Copied %s/%s bytes", copied, total)
+        total_size = sum(_path_size(p) for p in sources)
+        copied_total = 0
+
+        def make_update(start_offset: int) -> Callable[[int, int], None]:
+            def _update(copied: int, total: int) -> None:
+                percent = (start_offset + copied) / total_size * 100 if total_size else 100
+                progress['value'] = percent
+                logger.debug("Copied %s/%s bytes", start_offset + copied, total_size)
+            return _update
 
         def retry_cb(seconds: int) -> None:
             status_var.set(f"Retrying in {seconds}s...")
             root.update_idletasks()
 
-        success = copy_with_permissions(
-            src,
-            dst,
-            cli=False,
-            root=root,
-            progress_cb=update,
-            retry_cb=retry_cb,
-        )
-        duration = time.time() - start
-        status_var.set("")
-        if success:
-            messagebox.showinfo("Transfer", f"Completed in {duration:.1f}s. See log for details.", parent=root)
-        else:
-            messagebox.showerror("Transfer", "Operation failed or canceled. See log for details.", parent=root)
+        def run() -> None:
+            nonlocal copied_total
+            success = True
+            for src in sources:
+                if control.cancel.is_set():
+                    success = False
+                    break
+                if os.path.isdir(src):
+                    base = os.path.basename(src.rstrip(os.sep))
+                    for r, _, files in os.walk(src):
+                        for f in files:
+                            if control.cancel.is_set():
+                                success = False
+                                break
+                            src_file = os.path.join(r, f)
+                            rel = os.path.relpath(src_file, src)
+                            dst = os.path.join(dst_root, base, rel)
+                            os.makedirs(os.path.dirname(dst), exist_ok=True)
+                            file_size = os.path.getsize(src_file)
+                            cb = make_update(copied_total)
+                            if not copy_with_permissions(
+                                src_file,
+                                dst,
+                                cli=False,
+                                root=root,
+                                progress_cb=cb,
+                                retry_cb=retry_cb,
+                                timeout=config.timeout,
+                                chunk_size=config.chunk_size,
+                                control=control,
+                            ):
+                                success = False
+                                break
+                            copied_total += file_size
+                        if not success:
+                            break
+                else:
+                    dst = os.path.join(dst_root, os.path.basename(src))
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    file_size = os.path.getsize(src)
+                    cb = make_update(copied_total)
+                    if not copy_with_permissions(
+                        src,
+                        dst,
+                        cli=False,
+                        root=root,
+                        progress_cb=cb,
+                        retry_cb=retry_cb,
+                        timeout=config.timeout,
+                        chunk_size=config.chunk_size,
+                        control=control,
+                    ):
+                        success = False
+                        break
+                    copied_total += file_size
+
+            duration = time.time() - start
+            def finish() -> None:
+                pause_btn.config(state="disabled")
+                resume_btn.config(state="disabled")
+                cancel_btn.config(state="disabled")
+                status_var.set("")
+                if success:
+                    messagebox.showinfo(
+                        "Transfer",
+                        f"Completed in {duration:.1f}s. See log for details.",
+                        parent=root,
+                    )
+                else:
+                    messagebox.showerror(
+                        "Transfer",
+                        "Operation failed or canceled. See log for details.",
+                        parent=root,
+                    )
+            root.after(0, finish)
+
+        threading.Thread(target=run, daemon=True).start()
 
     tk.Button(frame, text="Transfer File", width=20, command=choose_and_transfer).pack(pady=5)
 
     tk.Button(frame, text="Generate Program Report", width=20, command=generate_report_gui).pack(pady=5)
+
+    tk.Button(frame, text="Restore Wizard", width=20, command=restore_wizard).pack(pady=5)
 
 
     root.mainloop()

--- a/utils/config.py
+++ b/utils/config.py
@@ -23,6 +23,8 @@ class Config:
     verbosity: str = "INFO"
     chunk_size: int = 1024 * 1024
     log_path: str = os.path.join(os.getcwd(), "winmigrate.log")
+    csv_log_path: str = os.path.join(os.getcwd(), "winmigrate.csv")
+    accessible: bool = False
 
 
 def _read_config(path: str) -> Dict[str, Any]:
@@ -69,6 +71,12 @@ def load_config(path: Optional[str] = None) -> Config:
             cfg.log_path = str(data["log_path"])
         if "log-path" in data:
             cfg.log_path = str(data["log-path"])
+        if "csv_log_path" in data:
+            cfg.csv_log_path = str(data["csv_log_path"])
+        if "csv-log-path" in data:
+            cfg.csv_log_path = str(data["csv-log-path"])
+        if "accessible" in data:
+            cfg.accessible = bool(data["accessible"])
     return cfg
 
 
@@ -81,4 +89,8 @@ def apply_cli_overrides(cfg: Config, args: argparse.Namespace) -> Config:
         cfg.chunk_size = args.chunk_size
     if getattr(args, "log_path", None) is not None:
         cfg.log_path = args.log_path
+    if getattr(args, "csv_log_path", None) is not None:
+        cfg.csv_log_path = args.csv_log_path
+    if getattr(args, "accessible", None) is not None:
+        cfg.accessible = args.accessible
     return cfg

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,84 @@
+import argparse
+import configparser
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(__file__))
+
+DEFAULT_CONFIG_PATHS = [
+    os.path.expanduser("~/.migration-assistant/config.json"),
+    os.path.join(PROJECT_DIR, "config.json"),
+]
+
+@dataclass
+class Config:
+    timeout: int = 300
+    verbosity: str = "INFO"
+    chunk_size: int = 1024 * 1024
+    log_path: str = os.path.join(os.getcwd(), "winmigrate.log")
+
+
+def _read_config(path: str) -> Dict[str, Any]:
+    ext = os.path.splitext(path)[1].lower()
+    with open(path, "r", encoding="utf-8") as f:
+        if ext == ".json":
+            return json.load(f)
+        if ext in (".yaml", ".yml"):
+            if yaml is None:
+                raise RuntimeError("PyYAML is not installed")
+            return yaml.safe_load(f) or {}
+        if ext == ".ini":
+            parser = configparser.ConfigParser()
+            parser.read_file(f)
+            section = parser.sections()[0] if parser.sections() else "DEFAULT"
+            return dict(parser[section])
+    return {}
+
+
+def load_config(path: Optional[str] = None) -> Config:
+    cfg = Config()
+    config_path = None
+    if path:
+        config_path = path
+    else:
+        for p in DEFAULT_CONFIG_PATHS:
+            if os.path.exists(p):
+                config_path = p
+                break
+    if config_path and os.path.exists(config_path):
+        try:
+            data = _read_config(config_path)
+        except Exception:
+            data = {}
+        if "timeout" in data:
+            cfg.timeout = int(data["timeout"])
+        if "verbosity" in data:
+            cfg.verbosity = str(data["verbosity"]).upper()
+        if "chunk_size" in data:
+            cfg.chunk_size = int(data["chunk_size"])
+        if "chunk-size" in data:
+            cfg.chunk_size = int(data["chunk-size"])
+        if "log_path" in data:
+            cfg.log_path = str(data["log_path"])
+        if "log-path" in data:
+            cfg.log_path = str(data["log-path"])
+    return cfg
+
+
+def apply_cli_overrides(cfg: Config, args: argparse.Namespace) -> Config:
+    if getattr(args, "timeout", None) is not None:
+        cfg.timeout = args.timeout
+    if getattr(args, "verbosity", None) is not None:
+        cfg.verbosity = str(args.verbosity).upper()
+    if getattr(args, "chunk_size", None) is not None:
+        cfg.chunk_size = args.chunk_size
+    if getattr(args, "log_path", None) is not None:
+        cfg.log_path = args.log_path
+    return cfg

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,27 +1,39 @@
 import logging
 import os
 from logging.handlers import RotatingFileHandler
+from typing import Optional
+
+_root_logger: Optional[logging.Logger] = None
 
 
-def get_logger(name: str = "WinMigrate") -> logging.Logger:
-    """Return a configured logger shared across the application."""
-    logger = logging.getLogger(name)
+def configure_logger(level: int = logging.DEBUG, log_path: Optional[str] = None) -> logging.Logger:
+    """Configure and return the shared root logger."""
+    global _root_logger
+    if _root_logger is None:
+        _root_logger = logging.getLogger("WinMigrate")
+    if log_path is None:
+        log_path = os.path.join(os.getcwd(), "winmigrate.log")
 
-    if not logger.handlers:
-        logger.setLevel(logging.DEBUG)
-        fmt = '%(asctime)s - %(levelname)s - %(message)s'
-        formatter = logging.Formatter(fmt)
+    for handler in list(_root_logger.handlers):
+        _root_logger.removeHandler(handler)
 
-        # Stream handler for console output
-        stream_handler = logging.StreamHandler()
-        stream_handler.setFormatter(formatter)
+    _root_logger.setLevel(level)
+    fmt = '%(asctime)s - %(levelname)s - %(message)s'
+    formatter = logging.Formatter(fmt)
 
-        # Rotating file handler to keep log history
-        log_path = os.path.join(os.getcwd(), 'winmigrate.log')
-        file_handler = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3)
-        file_handler.setFormatter(formatter)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
 
-        logger.addHandler(stream_handler)
-        logger.addHandler(file_handler)
+    file_handler = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3)
+    file_handler.setFormatter(formatter)
 
-    return logger
+    _root_logger.addHandler(stream_handler)
+    _root_logger.addHandler(file_handler)
+    return _root_logger
+
+
+def get_logger(name: str = __name__) -> logging.Logger:
+    """Return a child logger of the shared root logger."""
+    if _root_logger is None:
+        configure_logger()
+    return logging.getLogger("WinMigrate").getChild(name)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -6,29 +6,41 @@ from typing import Optional
 _root_logger: Optional[logging.Logger] = None
 
 
-def configure_logger(level: int = logging.DEBUG, log_path: Optional[str] = None) -> logging.Logger:
+def configure_logger(
+    level: int = logging.DEBUG,
+    log_path: Optional[str] = None,
+    csv_log_path: Optional[str] = None,
+    accessible: bool = False,
+) -> logging.Logger:
     """Configure and return the shared root logger."""
     global _root_logger
     if _root_logger is None:
         _root_logger = logging.getLogger("WinMigrate")
     if log_path is None:
         log_path = os.path.join(os.getcwd(), "winmigrate.log")
+    if csv_log_path is None:
+        csv_log_path = os.path.splitext(log_path)[0] + ".csv"
 
     for handler in list(_root_logger.handlers):
         _root_logger.removeHandler(handler)
 
     _root_logger.setLevel(level)
     fmt = '%(asctime)s - %(levelname)s - %(message)s'
-    formatter = logging.Formatter(fmt)
+    simple_fmt = '%(levelname)s: %(message)s'
+    formatter = logging.Formatter(simple_fmt if accessible else fmt)
 
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
 
     file_handler = RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3)
-    file_handler.setFormatter(formatter)
+    file_handler.setFormatter(logging.Formatter(fmt))
+
+    csv_handler = RotatingFileHandler(csv_log_path, maxBytes=1_000_000, backupCount=3)
+    csv_handler.setFormatter(logging.Formatter('%(asctime)s,%(levelname)s,"%(message)s"'))
 
     _root_logger.addHandler(stream_handler)
     _root_logger.addHandler(file_handler)
+    _root_logger.addHandler(csv_handler)
     return _root_logger
 
 

--- a/utils/programs.py
+++ b/utils/programs.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import json
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -82,8 +83,12 @@ def scan_installed_programs() -> List[ProgramInfo]:
     return progs
 
 
-def generate_report(output_dir: str) -> str:
-    """Generate a markdown report of installed programs."""
+def generate_report(output_dir: str, *, json_file: bool = True) -> str:
+    """Generate a markdown report of installed programs.
+
+    If ``json_file`` is True, also write a ``installed_programs.json`` file
+    containing the program data for use in restore scripts.
+    """
     os.makedirs(output_dir, exist_ok=True)
     programs = scan_installed_programs()
     lines = ["# Installed Programs", ""]
@@ -97,5 +102,10 @@ def generate_report(output_dir: str) -> str:
     path = os.path.join(output_dir, "installed_programs.md")
     with open(path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
+    if json_file:
+        json_path = os.path.join(output_dir, "installed_programs.json")
+        with open(json_path, "w", encoding="utf-8") as jf:
+            json.dump([p.__dict__ for p in programs], jf, indent=2)
+        logger.info("Generated installed programs JSON at %s", json_path)
     logger.info("Generated installed programs report at %s", path)
     return path

--- a/utils/restore.py
+++ b/utils/restore.py
@@ -1,0 +1,45 @@
+import os
+from typing import List, Optional, Tuple
+
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def generate_restore_script(
+    pairs: List[Tuple[str, str]],
+    output_path: str,
+    program_json: Optional[str] = None,
+) -> str:
+    """Generate a PowerShell script to restore files and optionally programs."""
+    lines = [
+        "# WinMigrate Restore Script",
+        "$ErrorActionPreference = 'Stop'",
+    ]
+    for original, backup in pairs:
+        if os.path.isdir(backup):
+            lines.append(
+                f"Copy-Item -Path \"{backup}\" -Destination \"{original}\" -Recurse -Force"
+            )
+        else:
+            lines.append(
+                f"Copy-Item -Path \"{backup}\" -Destination \"{original}\" -Force"
+            )
+    if program_json:
+        lines.append("")
+        lines.append("# Attempt program reinstalls")
+        lines.append(f"$programs = Get-Content \"{program_json}\" | ConvertFrom-Json")
+        lines.append("foreach ($p in $programs) {")
+        lines.append("    if ($p.url) {")
+        lines.append(
+            "        try { Invoke-WebRequest -Uri $p.url -OutFile \"$env:TEMP\\$($p.name).exe\"; Start-Process \"$env:TEMP\\$($p.name).exe\" -Wait }"
+        )
+        lines.append(
+            "        catch { Write-Host \"Failed to install $($p.name): $_\" }"
+        )
+        lines.append("    }")
+        lines.append("}")
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    logger.info("Restore script saved to %s", output_path)
+    return output_path

--- a/utils/transfer_control.py
+++ b/utils/transfer_control.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+from threading import Event
+
+@dataclass
+class TransferControl:
+    """Control flags for transfers."""
+
+    pause: Event = field(default_factory=Event)
+    cancel: Event = field(default_factory=Event)


### PR DESCRIPTION
## Summary
- add `utils/config.py` for loading config files and applying CLI overrides
- allow setting timeout, verbosity, chunk size and log path via config or CLI
- share root logger and enable reconfiguration
- support configurable chunk size through permission helpers
- include sample `config.json`
- add pause/resume functionality with `TransferControl`
- update CLI and GUI for pausing, canceling and resuming transfers
- add GUI dialog for custom file/folder selection with preset saving
- add CLI preset support for saving and reusing selections
- add restore script generator and GUI restore wizard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --installed-report testdir`
- `python main.py --gui` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_685c2235287883289b6a27d9f749fadd