### PR TITLE
Add initial tests and linting setup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E302,E305,W391,E203,W503

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 3.8
+ignore_missing_imports = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -v

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# Test and Lint Instructions
+
+## Running tests
+
+```bash
+python -m pytest
+```
+
+## Running linters
+
+```bash
+flake8
+mypy  # optional type checking
+```

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,47 @@
+import builtins
+from unittest import mock
+
+
+from utils.migration import (
+    compute_hash,
+    ensure_admin,
+    get_installed_programs,
+    resume_transfer,
+    validate_path,
+)
+
+
+def test_compute_hash_sha256():
+    data = b"hello"
+    assert (
+        compute_hash(data, "sha256")
+        == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    )
+
+
+def test_validate_path(tmp_path):
+    f = tmp_path / "file.txt"
+    f.write_text("hi")
+    assert validate_path(str(f))
+    assert not validate_path(str(f) + "_missing")
+
+
+def test_resume_transfer(tmp_path):
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"ABCDEFG")
+    part = resume_transfer(str(f), 3)
+    assert part == b"DEFG"
+
+
+def test_ensure_admin_fallback():
+    with mock.patch("utils.migration.requires_elevation", return_value=True):
+        with mock.patch.object(builtins, "print") as mock_print:
+            assert not ensure_admin()
+            mock_print.assert_called_with("Elevation required. Falling back.")
+
+
+def test_installed_program_fields():
+    programs = get_installed_programs()
+    assert programs, "Expected at least one program"
+    for prog in programs:
+        assert {"name", "version", "install_date"} <= prog.keys()

--- a/utils/migration.py
+++ b/utils/migration.py
@@ -1,0 +1,52 @@
+import hashlib
+import os
+from typing import Dict, List
+
+
+def compute_hash(data: bytes, algorithm: str = "sha256") -> str:
+    """Return a hexadecimal digest for the provided data."""
+    h = hashlib.new(algorithm)
+    h.update(data)
+    return h.hexdigest()
+
+
+def validate_path(path: str) -> bool:
+    """Return True if the given path exists on the filesystem."""
+    return os.path.exists(path)
+
+
+def resume_transfer(file_path: str, previous_size: int) -> bytes:
+    """Read the remainder of the file starting from ``previous_size`` bytes."""
+    with open(file_path, "rb") as f:
+        f.seek(previous_size)
+        return f.read()
+
+
+def requires_elevation() -> bool:
+    """Return True if the current process lacks administrative privileges."""
+    try:
+        return os.getuid() != 0  # type: ignore[attr-defined]
+    except AttributeError:
+        try:
+            import ctypes  # type: ignore
+            windll = getattr(ctypes, "windll", None)
+            if windll is not None:
+                return windll.shell32.IsUserAnAdmin() == 0
+            return True
+        except Exception:
+            return True
+
+
+def ensure_admin() -> bool:
+    """Check for admin rights and prompt if elevation is required."""
+    if requires_elevation():
+        print("Elevation required. Falling back.")
+        return False
+    return True
+
+
+def get_installed_programs() -> List[Dict[str, str]]:
+    """Return information about installed programs (placeholder)."""
+    return [
+        {"name": "ExampleApp", "version": "1.0", "install_date": "2020-01-01"}
+    ]


### PR DESCRIPTION
## Summary
- implement helper functions for hashing, path validation, transfer resume and admin checks
- create pytest-based unit tests covering these helpers
- configure flake8, mypy and pytest
- provide instructions for running tests and linters

## Testing
- `pytest -q`
- `flake8`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_685f4a87ba008328a4b6a60f6aec2410