### PR TITLE
Add basic file transfer GUI

### DIFF
--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -1,6 +1,8 @@
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
+from functools import partial
+
 from cli.cli_main import transfer
 from utils.logger import get_logger
 
@@ -17,7 +19,10 @@ def launch_gui() -> None:
         src_dir = filedialog.askdirectory(parent=root, title="Select source directory")
         if not src_dir:
             return
-        dst_dir = filedialog.askdirectory(parent=root, title="Select destination directory")
+        dst_dir = filedialog.askdirectory(
+            parent=root,
+            title="Select destination directory",
+        )
         if not dst_dir:
             return
         transfer(src_dir, dst_dir)
@@ -35,7 +40,7 @@ def launch_gui() -> None:
             root,
             text=method,
             width=20,
-            command=lambda m=method: select_method(m),
+            command=partial(select_method, method),
         ).pack(pady=5)
 
     tk.Label(root, text="(Functionality coming soon)").pack(pady=10)

--- a/gui/gui_main.py
+++ b/gui/gui_main.py
@@ -1,5 +1,7 @@
 import tkinter as tk
+from tkinter import filedialog, messagebox
 
+from cli.cli_main import transfer
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -10,11 +12,31 @@ def launch_gui() -> None:
     root = tk.Tk()
     root.title("WinMigrate - Transfer Method Selection")
 
+    def select_method(method: str) -> None:
+        logger.info("Selected transfer method: %s", method)
+        src_dir = filedialog.askdirectory(parent=root, title="Select source directory")
+        if not src_dir:
+            return
+        dst_dir = filedialog.askdirectory(parent=root, title="Select destination directory")
+        if not dst_dir:
+            return
+        transfer(src_dir, dst_dir)
+        messagebox.showinfo(
+            "Transfer Complete",
+            f"Transferred files from {src_dir} to {dst_dir}",
+            parent=root,
+        )
+
     tk.Label(root, text="Select Transfer Method").pack(pady=10)
 
     methods = ["USB Drive", "Network", "External HDD"]
     for method in methods:
-        tk.Button(root, text=method, width=20).pack(pady=5)
+        tk.Button(
+            root,
+            text=method,
+            width=20,
+            command=lambda m=method: select_method(m),
+        ).pack(pady=5)
 
     tk.Label(root, text="(Functionality coming soon)").pack(pady=10)
 


### PR DESCRIPTION
## Summary
- implement callbacks in GUI
- allow selecting source and destination directories
- reuse CLI transfer function to copy files

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686403f19b388328afc14efcb7539abf